### PR TITLE
Added waves-effect to main menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,25 +26,25 @@
       <a id="logo-container" href="{{ site.baseurl }}/" class="brand-logo"><img src="{{ site.baseurl }}/images/logo-100.png" width="100" height="100" title="Logo"/></a>
 
       <ul class="right hide-on-med-and-down">
-        <li><a href="#">About</a></li>
-        <li><a href="#">Blog</a></li>
-        <li><a href="#">Screenshots</a></li>
-        <li><a href="#">Develop</a></li>
-        <li><a href="#">Get Involved</a></li>
-        <li><a href="#">Support</a></li>
-        <li><a href="#">Download</a></li>
+        <li class="waves-effect"><a href="#">About</a></li>
+        <li class="waves-effect"><a href="#">Blog</a></li>
+        <li class="waves-effect"><a href="#">Screenshots</a></li>
+        <li class="waves-effect"><a href="#">Develop</a></li>
+        <li class="waves-effect"><a href="#">Get Involved</a></li>
+        <li class="waves-effect"><a href="#">Support</a></li>
+        <li class="waves-effect"><a href="#">Download</a></li>
       </ul>
 
       <ul id="nav-mobile" class="side-nav">
-        <li><a href="#">About</a></li>
-        <li><a href="#">Blog</a></li>
-        <li><a href="#">Screenshots</a></li>
-        <li><a href="#">Develop</a></li>
-        <li><a href="#">Get Involved</a></li>
-        <li><a href="#">Support</a></li>
-        <li><a href="#">Download</a></li>
+        <li><a class="waves-effect" href="#">About</a></li>
+        <li><a class="waves-effect" href="#">Blog</a></li>
+        <li><a class="waves-effect" href="#">Screenshots</a></li>
+        <li><a class="waves-effect" href="#">Develop</a></li>
+        <li><a class="waves-effect" href="#">Get Involved</a></li>
+        <li><a class="waves-effect" href="#">Support</a></li>
+        <li><a class="waves-effect" href="#">Download</a></li>
       </ul>
-      <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
+      <a href="#" data-activates="nav-mobile" class="button-collapse waves-effect"><i class="material-icons">menu</i></a>
     </div>
   </nav>
 


### PR DESCRIPTION
Added `waves-effect` in desktop-mode to `li`, because with `<a class="waves-effect" [...]>`, the waves-effect is a little bit bigger than the actual menu button.