### PR TITLE
Use public Transifex url

### DIFF
--- a/get-involved.html
+++ b/get-involved.html
@@ -114,7 +114,7 @@ theme: brown-light_blue
         <ol>
             <li>Signup for an account on <a href="https://www.transifex.com/signup/" target="_blank">Transifex</a>.</li>
             <li>Verify your email address, log in and then go to the
-                <a href="https://www.transifex.com/lirios/" target="_blank">Liri project page</a>.</li>
+                <a href="https://www.transifex.com/lirios/public/" target="_blank">Liri project page</a>.</li>
             <li>Choose the language you want to translate or, if it isn't listed, click the
                 <strong>Request Language</strong> button.</li>
             <li>If you are requesting a new language, select or search for it in the
@@ -127,7 +127,7 @@ theme: brown-light_blue
             <li>If you are using the Transifex editor, choose the option &quot;Untranslated&quot;
                 and you will see all the untranslated strings on the left bar.</li>
         </ol>
-        <a class="waves-effect waves-light btn" href="https://www.transifex.com/lirios" target="_blank">Translate</a>
+        <a class="waves-effect waves-light btn" href="https://www.transifex.com/lirios/public/" target="_blank">Translate</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Apparently there is a separate url for the public transifex page.