### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2.7
+  - 2.4.5
 
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", ">= 3.6.3"
+gem "jekyll", ">= 3.6.3", "< 4.0.0"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima"


### PR DESCRIPTION
Despite having update rvm in 4d89164, we still face CI failure
due to dependency issues, see:
https://travis-ci.org/lirios/lirios.github.io/builds/592480697

Update to ruby 2.3.x to fix the problem.