### PR TITLE
Fix icon sizing in features section

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,10 +68,6 @@ layout: default
     margin-right: 32px;
     text-align: justify;
   }
-    
-  .md-48 {
-    font-size: 64px;
-  }
 </style>
 
 <div class="liri-laptop mdl-typography--text-center">
@@ -97,7 +93,7 @@ layout: default
   <div class="liri-features-section">
     <div class="mdl-grid">
       <div class="mdl-cell mdl-cell--4-col mdl-cell--12-col-phone mdl-cell--12-col-tablet">
-        <div class="mdl-typography--text-center"><i class="material-icons md-48">flash_on</i></div>
+        <div class="mdl-typography--text-center"><i class="material-icons" style="font-size: 48px">flash_on</i></div>
         <h5 class="mdl-typography--text-center">Modern Features</h5>
 
         <p>
@@ -106,7 +102,7 @@ layout: default
         </p>
       </div>
       <div class="mdl-cell mdl-cell--4-col mdl-cell--12-col-phone mdl-cell--12-col-tablet">
-        <div class="mdl-typography--text-center"><i class="material-icons md-48">group</i></div>
+        <div class="mdl-typography--text-center"><i class="material-icons" style="font-size: 48px">group</i></div>
         <h5 class="mdl-typography--text-center">User Experience Focused</h5>
 
         <p>
@@ -116,7 +112,7 @@ layout: default
         </p>
       </div>
       <div class="mdl-cell mdl-cell--4-col mdl-cell--12-col-phone mdl-cell--12-col-tablet">
-        <div class="mdl-typography--text-center"><i class="material-icons md-48">settings</i></div>
+        <div class="mdl-typography--text-center"><i class="material-icons" style="font-size: 48px">settings</i></div>
         <h5 class="mdl-typography--text-center">Open Source and Open Governance</h5>
 
         <p>


### PR DESCRIPTION
Fixes the icon sizing and sets it to 48 px instead of current 24 for visual balance (.md-48 didn't work previously).